### PR TITLE
Modifica funzione aggiungi

### DIFF
--- a/Esami/2016_08.sml
+++ b/Esami/2016_08.sml
@@ -15,7 +15,7 @@
 
 (*  ed un intero può essere aggiunto ad un insieme tramite la funzione aggiungi: *)
 
-    val aggiungi = fn f:insiemediinteri => fn x:int => (fn n:int => if (n = x) then true else false ):insiemediinteri;
+    val aggiungi = fn f:insiemediinteri => fn x:int => (fn n:int => if (n = x orelse f n) then true else false ):insiemediinteri;
 
 (*  É possibile verificare se un intero è contenuto in un insieme tramite la funzione contiene: *)
     


### PR DESCRIPTION
L'insieme B generato dalla funzione aggiungi non controlla se l'insieme A (a cui è stato aggiunto un elemento) conteneva l'elemento.

```sml
val insA = aggiungi vuoto 1;
val insB = aggiungi insA 2;
contiene insB 1; (* ritorna falso *)
```